### PR TITLE
Fantasy Land 1.0.x & 2.0.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 
 ## API
 
-Free implements [Functor](https://github.com/fantasyland/fantasy-land#functor), [Applicative](https://github.com/fantasyland/fantasy-land#applicative) and [Monad](https://github.com/fantasyland/fantasy-land#monad) specifications.
+Free implements [Functor](https://github.com/fantasyland/fantasy-land#functor), [Applicative](https://github.com/fantasyland/fantasy-land#applicative), [ChainRec](https://github.com/fantasyland/fantasy-land#chainrec) and [Monad](https://github.com/fantasyland/fantasy-land#monad) specifications.
 
-### Applicative, Functor and Monad functions:
+### Functor, Applicative, ChainRec and Monad functions:
 
 - Free.prototype.`map :: Free i a -> (a -> b) -> Free i b`
-- Free.`of :: a -> Free i a`
 - Free.prototype.`ap :: Free i a -> Free i (a -> b) -> Free i b`
 - Free.prototype.`chain :: Free i a -> (a -> Free i b) -> Free i b`
+- Free.`chainRec :: ((a -> c, b -> c, a) -> Free i c, a) -> Free i b`
+- Free.`of :: a -> Free i a`
 
 
 ### Free structure functions:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Free implements [Functor](https://github.com/fantasyland/fantasy-land#functor), 
 
 - Free.prototype.`map :: Free i a -> (a -> b) -> Free i b`
 - Free.`of :: a -> Free i a`
-- Free.prototype.`ap :: Free i (a -> b) -> Free i a -> Free i b`
+- Free.prototype.`ap :: Free i a -> Free i (a -> b) -> Free i b`
 - Free.prototype.`chain :: Free i a -> (a -> Free i b) -> Free i b`
 
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "url": "https://github.com/safareli/free/issues"
   },
   "homepage": "https://github.com/safareli/free#readme",
+  "dependencies": {
+    "fantasy-land": "0.2.1"
+  },
   "devDependencies": {
     "babel-cli": "6.10.1",
     "babel-core": "6.10.4",
@@ -56,7 +59,6 @@
     "eslint-plugin-promise": "1.3.2",
     "eslint-plugin-standard": "1.3.2",
     "fantasy-combinators": "0.0.1",
-    "fantasy-land": "0.2.1",
     "ghooks": "1.3.0",
     "jsverify": "0.7.1",
     "nodemon": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/safareli/free#readme",
   "dependencies": {
-    "fantasy-land": "0.2.1"
+    "fantasy-land": "1.0.x"
   },
   "devDependencies": {
     "babel-cli": "6.10.1",

--- a/src/fl-compatibility.js
+++ b/src/fl-compatibility.js
@@ -31,8 +31,15 @@ const functions = flCompatibilityDefinition.reduce((res, definition) => {
 
 const patch = (constructor) => {
   for (let definition of flCompatibilityDefinition) {
-    constructor.prototype[fl[definition.name]] = constructor[definition.name]
-    constructor[fl[definition.name]] = constructor[definition.name]
+    if (constructor.prototype[definition.srcName]) {
+      constructor.prototype[definition.flName] = constructor.prototype[definition.srcName]
+      if (definition.couldBeInConstructor) {
+        constructor[definition.flName] = constructor.prototype[definition.srcName]
+      }
+    }
+    if (constructor[definition.srcName]) {
+      constructor[definition.flName] = constructor[definition.srcName]
+    }
   }
 }
 

--- a/src/fl-compatibility.js
+++ b/src/fl-compatibility.js
@@ -1,19 +1,19 @@
 const fl = require('fantasy-land')
 const flCompatibilityDefinition = [
-  { flName: fl['of'], srcName: 'of', couldBeInConstructor: true },
-  { flName: fl['map'], srcName: 'map', couldBeInConstructor: false },
-  { flName: fl['ap'], srcName: 'ap', couldBeInConstructor: false },
-  { flName: fl['chain'], srcName: 'chain', couldBeInConstructor: false },
+  { flName: fl['of'], srcName: 'of', isStatic: true },
+  { flName: fl['map'], srcName: 'map', isStatic: false },
+  { flName: fl['ap'], srcName: 'ap', isStatic: false },
+  { flName: fl['chain'], srcName: 'chain', isStatic: false },
 ]
 
-const makeFunction = (methodName, fallbackMethodName, couldBeInConstructor) => (obj, ...args) => {
+const makeFunction = (methodName, fallbackMethodName, isStatic) => (obj, ...args) => {
   if (obj[methodName]) {
     return obj[methodName](...args)
-  } else if (couldBeInConstructor && obj.constructor[methodName]) {
+  } else if (isStatic && obj.constructor[methodName]) {
     return obj.constructor[methodName](...args)
   } else if (obj[fallbackMethodName]) {
     return obj[fallbackMethodName](...args)
-  } else if (couldBeInConstructor && obj.constructor[fallbackMethodName]) {
+  } else if (isStatic && obj.constructor[fallbackMethodName]) {
     return obj.constructor[fallbackMethodName](...args)
   } else {
     throw new TypeError(`there is no method named ${methodName} nor ${fallbackMethodName} defined for ${obj}`)
@@ -24,7 +24,7 @@ const functions = flCompatibilityDefinition.reduce((res, definition) => {
   res[definition.srcName] = makeFunction(
     definition.flName,
     definition.srcName,
-    definition.couldBeInConstructor
+    definition.isStatic
   )
   return res
 }, {})
@@ -33,11 +33,11 @@ const patch = (constructor) => {
   for (let definition of flCompatibilityDefinition) {
     if (constructor.prototype[definition.srcName]) {
       constructor.prototype[definition.flName] = constructor.prototype[definition.srcName]
-      if (definition.couldBeInConstructor) {
-        constructor[definition.flName] = constructor.prototype[definition.srcName]
-      }
     }
     if (constructor[definition.srcName]) {
+      if (definition.isStatic) {
+        constructor.prototype[definition.flName] = constructor[definition.srcName]
+      }
       constructor[definition.flName] = constructor[definition.srcName]
     }
   }

--- a/src/fl-compatibility.js
+++ b/src/fl-compatibility.js
@@ -7,6 +7,7 @@ const flCompatibilityDefinition = [
   { flName: fl['chain'], srcName: 'chain', isStatic: false },
 ]
 
+/* istanbul ignore next */
 const makeFunction = (methodName, fallbackMethodName, isStatic) => (obj, ...args) => {
   if (obj[methodName]) {
     return obj[methodName](...args)

--- a/src/fl-compatibility.js
+++ b/src/fl-compatibility.js
@@ -1,0 +1,42 @@
+const fl = require('fantasy-land')
+const flCompatibilityDefinition = [
+  { flName: fl['of'], srcName: 'of', couldBeInConstructor: true },
+  { flName: fl['map'], srcName: 'map', couldBeInConstructor: false },
+  { flName: fl['ap'], srcName: 'ap', couldBeInConstructor: false },
+  { flName: fl['chain'], srcName: 'chain', couldBeInConstructor: false },
+]
+
+const makeFunction = (methodName, fallbackMethodName, couldBeInConstructor) => (obj, ...args) => {
+  if (obj[methodName]) {
+    return obj[methodName](...args)
+  } else if (couldBeInConstructor && obj.constructor[methodName]) {
+    return obj.constructor[methodName](...args)
+  } else if (obj[fallbackMethodName]) {
+    return obj[fallbackMethodName](...args)
+  } else if (couldBeInConstructor && obj.constructor[fallbackMethodName]) {
+    return obj.constructor[fallbackMethodName](...args)
+  } else {
+    throw new TypeError(`there is no method named ${methodName} nor ${fallbackMethodName} defined for ${obj}`)
+  }
+}
+
+const functions = flCompatibilityDefinition.reduce((res, definition) => {
+  res[definition.srcName] = makeFunction(
+    definition.flName,
+    definition.srcName,
+    definition.couldBeInConstructor
+  )
+  return res
+}, {})
+
+const patch = (constructor) => {
+  for (let definition of flCompatibilityDefinition) {
+    constructor.prototype[fl[definition.name]] = constructor[definition.name]
+    constructor[fl[definition.name]] = constructor[definition.name]
+  }
+}
+
+module.exports = {
+  functions,
+  patch,
+}

--- a/src/fl-compatibility.js
+++ b/src/fl-compatibility.js
@@ -1,6 +1,7 @@
 const fl = require('fantasy-land')
 const flCompatibilityDefinition = [
   { flName: fl['of'], srcName: 'of', isStatic: true },
+  { flName: fl['chainRec'], srcName: 'chainRec', isStatic: true },
   { flName: fl['map'], srcName: 'map', isStatic: false },
   { flName: fl['ap'], srcName: 'ap', isStatic: false },
   { flName: fl['chain'], srcName: 'chain', isStatic: false },

--- a/src/free.js
+++ b/src/free.js
@@ -1,3 +1,4 @@
+const fl = require('fantasy-land')
 const { functions, patch } = require('./fl-compatibility')
 const { of, map, ap, chain } = functions
 
@@ -60,9 +61,9 @@ Free.Lift = Lift
 Free.Chain = Chain
 
 /* istanbul ignore else */
-if (Function.prototype.map == null) {
+if (Function.prototype[fl.map] == null) {
   // eslint-disable-next-line no-extend-native
-  Object.defineProperty(Function.prototype, 'map', {
+  Object.defineProperty(Function.prototype, fl.map, {
     value: function(g) {
       const f = this
       return function(x) { return g(f(x)) }
@@ -135,9 +136,9 @@ Free.prototype.retract = function(m) {
 Free.prototype.foldMap = function(f, m) {
   return m.chainRec((next, done, v) => v.cata({
     Pure: (x) => map(of(m, x), done),
-    Lift: (x, g) => map(f(x), (a) => done(g(a))),
+    Lift: (x, g) => map(f(x), compose(done, g)),
     Ap: (x, y) => map(ap(x.foldMap(f, m), y.foldMap(f, m)), done),
-    Chain: (x, g) => map(x.foldMap(f, m), (a) => next(g(a))),
+    Chain: (x, g) => map(x.foldMap(f, m), compose(next, g)),
   }), this)
 }
 

--- a/src/free.js
+++ b/src/free.js
@@ -1,5 +1,5 @@
 const { functions, patch } = require('./fl-compatibility')
-const { of, map, ap } = functions
+const { of, map, ap, chain } = functions
 
 // data Free i a
 //   = Ap { x: (Free i b), y: (Free i (b -> a)) }
@@ -120,7 +120,7 @@ Free.prototype.chain = function(f) {
     Pure: (x) => f(x),
     Ap: () => Free.Chain(this, f),
     Lift: () => Free.Chain(this, f),
-    Chain: (x, g) => Free.Chain(x, (v) => g(v).chain(f)),
+    Chain: (x, g) => Free.Chain(x, (v) => chain(g(v), f)),
   })
 }
 
@@ -148,7 +148,8 @@ Free.prototype.graft = function(f) {
 const chainRecNext = (value) => ({ done: false, value })
 const chainRecDone = (value) => ({ done: true, value })
 
-Free.chainRec = (f, i) => f(chainRecNext, chainRecDone, i).chain(
+Free.chainRec = (f, i) => chain(
+  f(chainRecNext, chainRecDone, i),
   ({ done, value }) => done ? Free.of(value) : Free.chainRec(f, value)
 )
 

--- a/src/free.js
+++ b/src/free.js
@@ -1,5 +1,5 @@
 const { functions, patch } = require('./fl-compatibility')
-const { of, map } = functions
+const { of, map, ap } = functions
 
 // data Free i a
 //   = Ap { x: (Free i b), y: (Free i (b -> a)) }
@@ -136,7 +136,7 @@ Free.prototype.foldMap = function(f, m) {
   return m.chainRec((next, done, v) => v.cata({
     Pure: (x) => map(of(m, x), done),
     Lift: (x, g) => map(f(x), (a) => done(g(a))),
-    Ap: (x, y) => map(y.foldMap(f, m).ap(x.foldMap(f, m)), done),
+    Ap: (x, y) => map(ap(y.foldMap(f, m), x.foldMap(f, m)), done),
     Chain: (x, g) => map(x.foldMap(f, m), (a) => next(g(a))),
   }), this)
 }

--- a/src/free.js
+++ b/src/free.js
@@ -108,10 +108,10 @@ Free.prototype.map = function(f) {
 
 Free.prototype.ap = function(y) {
   return this.cata({
-    Pure: (f) => map(y, f),
-    Ap: () => Free.Ap(y, this),
-    Lift: () => Free.Ap(y, this),
-    Chain: () => Free.Ap(y, this),
+    Pure: (x) => map(y, (f) => f(x)),
+    Ap: () => Free.Ap(this, y),
+    Lift: () => Free.Ap(this, y),
+    Chain: () => Free.Ap(this, y),
   })
 }
 
@@ -136,7 +136,7 @@ Free.prototype.foldMap = function(f, m) {
   return m.chainRec((next, done, v) => v.cata({
     Pure: (x) => map(of(m, x), done),
     Lift: (x, g) => map(f(x), (a) => done(g(a))),
-    Ap: (x, y) => map(ap(y.foldMap(f, m), x.foldMap(f, m)), done),
+    Ap: (x, y) => map(ap(x.foldMap(f, m), y.foldMap(f, m)), done),
     Chain: (x, g) => map(x.foldMap(f, m), (a) => next(g(a))),
   }), this)
 }

--- a/src/free.js
+++ b/src/free.js
@@ -1,5 +1,5 @@
 const { functions, patch } = require('./fl-compatibility')
-const { map } = functions
+const { of, map } = functions
 
 // data Free i a
 //   = Ap { x: (Free i b), y: (Free i (b -> a)) }
@@ -134,7 +134,7 @@ Free.prototype.retract = function(m) {
 
 Free.prototype.foldMap = function(f, m) {
   return m.chainRec((next, done, v) => v.cata({
-    Pure: (x) => map(m.of(x), done),
+    Pure: (x) => map(of(m, x), done),
     Lift: (x, g) => map(f(x), (a) => done(g(a))),
     Ap: (x, y) => map(y.foldMap(f, m).ap(x.foldMap(f, m)), done),
     Chain: (x, g) => map(x.foldMap(f, m), (a) => next(g(a))),

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -4,7 +4,7 @@ const { Free, Future } = require('./lib')
 test('Check for concurrency', (t) => {
   const shout = (tag, ms) => Free.liftF({tag: `${tag}.${ms}`, ms})
   const pear3 = x => y => z => [x, y, z]
-  const ap = (v, f) => f.ap(v)
+  const ap = (v, f) => v.ap(f)
   const lift2 = (f, a, b) => {
     return ap(b, a.map(function(a) {
       return function(b) {

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -23,7 +23,7 @@ test('Check for concurrency', (t) => {
   }
   let orders = { start: [], end: [] }
   ap(
-    shout('out.ap', 10),
+    shout('out.ap', 10).ap(Free.of((a) => a)),
     lift3(
       pear3,
       shout('out.ap', 500),

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -1,19 +1,18 @@
 const { test } = require('tap')
-const { Free, Future } = require('./lib')
+const { Free, Future, ap, map } = require('./lib')
 
 test('Check for concurrency', (t) => {
   const shout = (tag, ms) => Free.liftF({tag: `${tag}.${ms}`, ms})
   const pear3 = x => y => z => [x, y, z]
-  const ap = (v, f) => v.ap(f)
   const lift2 = (f, a, b) => {
-    return ap(b, a.map(function(a) {
+    return ap(b, map(a, function(a) {
       return function(b) {
         return f(a)(b)
       }
     }))
   }
   const lift3 = (f, a, b, c) => {
-    return ap(c, ap(b, a.map(function(a) {
+    return ap(c, ap(b, map(a, function(a) {
       return function(b) {
         return function(c) {
           return f(a)(b)(c)

--- a/test/laws.js
+++ b/test/laws.js
@@ -40,7 +40,7 @@ test('Is stack safe', t => {
 test('Check Free structure function equivalencies', (t) => {
   const compose = (f, g) => (x) => f(g(x))
   const id = x => x
-  const tree = Free.liftF(1).map((a) => (b) => [a, b]).ap(Free.of(10))
+  const tree = Free.of(10).ap(Free.liftF(1).map((a) => (b) => [a, b]))
   const foldTree = (t) => t.foldMap((a) => Identity(a), Identity).x
   const treeEq = (a, b) => equals(foldTree(a), foldTree(b))
 

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -1,5 +1,6 @@
 const Ɐ = require('jsverify')
 const Free = require('../../src/free.js')
+const { functions } = require('../../src/fl-compatibility.js')
 const { Future, Identity } = require('ramda-fantasy')
 
 // make Future's `ap` compatible with FL@1
@@ -10,8 +11,8 @@ Future.prototype[ap] = function(f) {
 
 Ɐ.any = Ɐ.oneof(Ɐ.falsy, Ɐ.json)
 
-module.exports = {
+module.exports = Object.assign({
   Free,
   Future,
   Identity,
-}
+}, functions)

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -2,6 +2,12 @@ const Ɐ = require('jsverify')
 const Free = require('../../src/free.js')
 const { Future, Identity } = require('ramda-fantasy')
 
+// make Future's `ap` compatible with FL@1
+const { ap } = require('fantasy-land')
+Future.prototype[ap] = function(f) {
+  return f.ap(this)
+}
+
 Ɐ.any = Ɐ.oneof(Ɐ.falsy, Ɐ.json)
 
 module.exports = {


### PR DESCRIPTION
This PR makes Free compatible with `fantasy-land@1.0.x`

Wait for [sanctuary-type-classes#2](https://github.com/sanctuary-js/sanctuary-type-classes/pull/2) to be published and then:
- [x] use sanctuary-type-classes instead of `fl-compatibility.js#functions`
- [x] remove `function.prototype.map ...`

Breaking change:
- Order of arguments to `ap` has changed in FL and here as well
- `foldMap` now takes Type Representative of target structure as we need access to `chainRec` with `of`
